### PR TITLE
Fix for warnings from Intel compiler on macOS.

### DIFF
--- a/hedley.h
+++ b/hedley.h
@@ -748,7 +748,7 @@
 #if defined(HEDLEY_DIAGNOSTIC_POP)
 #  undef HEDLEY_DIAGNOSTIC_POP
 #endif
-#if defined(__clang__)
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
 #  define HEDLEY_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
 #elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)


### PR DESCRIPTION
On macOS using the latest Intel compilers, the code emits these warnings:

```shell
hedley.h(1261): warning #161: unrecognized #pragma
  HEDLEY_DIAGNOSTIC_PUSH
  ^

hedley.h(1287): warning #161: unrecognized #pragma
  HEDLEY_DIAGNOSTIC_POP
```

This seems to be because the Intel cxx compiler, icpc, defines the __clang__ macro. I added an additional check on the relevant part of the code to make sure an Intel compiler is not being used. I wasn't sure if there was a better way you prefer, but the warnings go away with this small change and did not seem to affect compilation with a clang compiler. 