### PR TITLE
Fix a rare definition of HEDLEY_IS_CONSTEXPR_

### DIFF
--- a/hedley.h
+++ b/hedley.h
@@ -1794,7 +1794,7 @@ HEDLEY_DIAGNOSTIC_POP
 #      define HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0), int*: 1, void*: 0)
 #    else
 #      include <stdint.h>
-#      define HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((intptr_t) * 0) : (int*) 0), int*: 1, void*: 0)
+#      define HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((intptr_t) ((expr) * 0)) : (int*) 0), int*: 1, void*: 0)
 #    endif
 #  elif \
        defined(HEDLEY_GCC_VERSION) || \


### PR DESCRIPTION
Tweak the `stdint.h`-requiring definition of `HEDLEY_IS_CONSTEXPR_` to behave like its neighbours.

The previous version dereferenced zero and ignored its argument.

