### PR TITLE
Dual-license as (CC0-1.0 OR MIT-0)

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,117 +1,15 @@
-Statement of Purpose
+Hedley - https://nemequ.github.io/hedley
+Created by Evan Nemerson <evan@nemerson.com>
 
-The laws of most jurisdictions throughout the world automatically
-confer exclusive Copyright and Related Rights (defined below) upon the
-creator and subsequent owner(s) (each and all, an "owner") of an
-original work of authorship and/or a database (each, a "Work").
+To the extent possible under law, the author(s) have dedicated all
+copyright and related and neighboring rights to this software to
+the public domain worldwide. This software is distributed without
+any warranty.
 
-Certain owners wish to permanently relinquish those rights to a Work
-for the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without
-fear of later claims of infringement build upon, modify, incorporate
-in other works, reuse and redistribute as freely as possible in any
-form whatsoever and for any purposes, including without limitation
-commercial purposes. These owners may contribute to the Commons to
-promote the ideal of a free culture and the further production of
-creative, cultural and scientific works, or to gain reputation or
-greater distribution for their Work in part through the use and
-efforts of others.
+Alternatively, and at your option, this software is available under the
+MIT No Attribution License (MIT-0); see the file COPYING-MIT-0.
 
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or
-she is an owner of Copyright and Related Rights in the Work,
-voluntarily elects to apply CC0 to the Work and publicly distribute
-the Work under its terms, with knowledge of his or her Copyright and
-Related Rights in the Work and the meaning and intended legal effect
-of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may
-   be protected by copyright and related or neighboring rights
-   ("Copyright and Related Rights"). Copyright and Related Rights
-   include, but are not limited to, the following:
-
-       i. the right to reproduce, adapt, distribute, perform, display,
-          communicate, and translate a Work;
-      ii. moral rights retained by the original author(s) and/or
-          performer(s);
-     iii. publicity and privacy rights pertaining to a person's image
-          or likeness depicted in a Work;
-      iv. rights protecting against unfair competition in regards to a
-          Work, subject to the limitations in paragraph 4(a), below;
-       v. rights protecting the extraction, dissemination, use and
-          reuse of data in a Work;
-      vi. database rights (such as those arising under Directive
-          96/9/EC of the European Parliament and of the Council of 11
-          March 1996 on the legal protection of databases, and under
-          any national implementation thereof, including any amended
-          or successor version of such directive); and
-     vii. other similar, equivalent or corresponding rights throughout
-          the world based on applicable law or treaty, and any
-          national implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in
-   contravention of, applicable law, Affirmer hereby overtly, fully,
-   permanently, irrevocably and unconditionally waives, abandons, and
-   surrenders all of Affirmer's Copyright and Related Rights and
-   associated claims and causes of action, whether now known or
-   unknown (including existing as well as future claims and causes of
-   action), in the Work (i) in all territories worldwide, (ii) for the
-   maximum duration provided by applicable law or treaty (including
-   future time extensions), (iii) in any current or future medium and
-   for any number of copies, and (iv) for any purpose whatsoever,
-   including without limitation commercial, advertising or promotional
-   purposes (the "Waiver"). Affirmer makes the Waiver for the benefit
-   of each member of the public at large and to the detriment of
-   Affirmer's heirs and successors, fully intending that such Waiver
-   shall not be subject to revocation, rescission, cancellation,
-   termination, or any other legal or equitable action to disrupt the
-   quiet enjoyment of the Work by the public as contemplated by
-   Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any
-   reason be judged legally invalid or ineffective under applicable
-   law, then the Waiver shall be preserved to the maximum extent
-   permitted taking into account Affirmer's express Statement of
-   Purpose. In addition, to the extent the Waiver is so judged
-   Affirmer hereby grants to each affected person a royalty-free, non
-   transferable, non sublicensable, non exclusive, irrevocable and
-   unconditional license to exercise Affirmer's Copyright and Related
-   Rights in the Work (i) in all territories worldwide, (ii) for the
-   maximum duration provided by applicable law or treaty (including
-   future time extensions), (iii) in any current or future medium and
-   for any number of copies, and (iv) for any purpose whatsoever,
-   including without limitation commercial, advertising or promotional
-   purposes (the "License"). The License shall be deemed effective as
-   of the date CC0 was applied by Affirmer to the Work. Should any
-   part of the License for any reason be judged legally invalid or
-   ineffective under applicable law, such partial invalidity or
-   ineffectiveness shall not invalidate the remainder of the License,
-   and in such case Affirmer hereby affirms that he or she will not
-   (i) exercise any of his or her remaining Copyright and Related
-   Rights in the Work or (ii) assert any associated claims and causes
-   of action with respect to the Work, in either case contrary to
-   Affirmer's express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
-   a. No trademark or patent rights held by Affirmer are waived,
-      abandoned, surrendered, licensed or otherwise affected by this
-      document.
-   b. Affirmer offers the Work as-is and makes no representations or
-      warranties of any kind concerning the Work, express, implied,
-      statutory or otherwise, including without limitation warranties
-      of title, merchantability, fitness for a particular purpose, non
-      infringement, or the absence of latent or other defects,
-      accuracy, or the present or absence of errors, whether or not
-      discoverable, all to the greatest extent permissible under
-      applicable law.
-   c. Affirmer disclaims responsibility for clearing rights of other
-      persons that may apply to the Work or any use thereof, including
-      without limitation any person's Copyright and Related Rights in
-      the Work. Further, Affirmer disclaims responsibility for
-      obtaining any necessary consents, permissions or other rights
-      required for any use of the Work.
-   d. Affirmer understands and acknowledges that Creative Commons is
-      not a party to this document and has no duty or obligation with
-      respect to this CC0 or use of the Work.
+For details, see <http://creativecommons.org/publicdomain/zero/1.0/> and the
+file COPYING-CC0-1.0, or <https://spdx.org/licenses/MIT-0.html> and the file
+COPYING-MIT-0.
+SPDX-License-Identifier: CC0-1.0 OR MIT-0

--- a/COPYING-CC0-1.0
+++ b/COPYING-CC0-1.0
@@ -1,0 +1,117 @@
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically
+confer exclusive Copyright and Related Rights (defined below) upon the
+creator and subsequent owner(s) (each and all, an "owner") of an
+original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work
+for the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without
+fear of later claims of infringement build upon, modify, incorporate
+in other works, reuse and redistribute as freely as possible in any
+form whatsoever and for any purposes, including without limitation
+commercial purposes. These owners may contribute to the Commons to
+promote the ideal of a free culture and the further production of
+creative, cultural and scientific works, or to gain reputation or
+greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or
+she is an owner of Copyright and Related Rights in the Work,
+voluntarily elects to apply CC0 to the Work and publicly distribute
+the Work under its terms, with knowledge of his or her Copyright and
+Related Rights in the Work and the meaning and intended legal effect
+of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may
+   be protected by copyright and related or neighboring rights
+   ("Copyright and Related Rights"). Copyright and Related Rights
+   include, but are not limited to, the following:
+
+       i. the right to reproduce, adapt, distribute, perform, display,
+          communicate, and translate a Work;
+      ii. moral rights retained by the original author(s) and/or
+          performer(s);
+     iii. publicity and privacy rights pertaining to a person's image
+          or likeness depicted in a Work;
+      iv. rights protecting against unfair competition in regards to a
+          Work, subject to the limitations in paragraph 4(a), below;
+       v. rights protecting the extraction, dissemination, use and
+          reuse of data in a Work;
+      vi. database rights (such as those arising under Directive
+          96/9/EC of the European Parliament and of the Council of 11
+          March 1996 on the legal protection of databases, and under
+          any national implementation thereof, including any amended
+          or successor version of such directive); and
+     vii. other similar, equivalent or corresponding rights throughout
+          the world based on applicable law or treaty, and any
+          national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in
+   contravention of, applicable law, Affirmer hereby overtly, fully,
+   permanently, irrevocably and unconditionally waives, abandons, and
+   surrenders all of Affirmer's Copyright and Related Rights and
+   associated claims and causes of action, whether now known or
+   unknown (including existing as well as future claims and causes of
+   action), in the Work (i) in all territories worldwide, (ii) for the
+   maximum duration provided by applicable law or treaty (including
+   future time extensions), (iii) in any current or future medium and
+   for any number of copies, and (iv) for any purpose whatsoever,
+   including without limitation commercial, advertising or promotional
+   purposes (the "Waiver"). Affirmer makes the Waiver for the benefit
+   of each member of the public at large and to the detriment of
+   Affirmer's heirs and successors, fully intending that such Waiver
+   shall not be subject to revocation, rescission, cancellation,
+   termination, or any other legal or equitable action to disrupt the
+   quiet enjoyment of the Work by the public as contemplated by
+   Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any
+   reason be judged legally invalid or ineffective under applicable
+   law, then the Waiver shall be preserved to the maximum extent
+   permitted taking into account Affirmer's express Statement of
+   Purpose. In addition, to the extent the Waiver is so judged
+   Affirmer hereby grants to each affected person a royalty-free, non
+   transferable, non sublicensable, non exclusive, irrevocable and
+   unconditional license to exercise Affirmer's Copyright and Related
+   Rights in the Work (i) in all territories worldwide, (ii) for the
+   maximum duration provided by applicable law or treaty (including
+   future time extensions), (iii) in any current or future medium and
+   for any number of copies, and (iv) for any purpose whatsoever,
+   including without limitation commercial, advertising or promotional
+   purposes (the "License"). The License shall be deemed effective as
+   of the date CC0 was applied by Affirmer to the Work. Should any
+   part of the License for any reason be judged legally invalid or
+   ineffective under applicable law, such partial invalidity or
+   ineffectiveness shall not invalidate the remainder of the License,
+   and in such case Affirmer hereby affirms that he or she will not
+   (i) exercise any of his or her remaining Copyright and Related
+   Rights in the Work or (ii) assert any associated claims and causes
+   of action with respect to the Work, in either case contrary to
+   Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+   a. No trademark or patent rights held by Affirmer are waived,
+      abandoned, surrendered, licensed or otherwise affected by this
+      document.
+   b. Affirmer offers the Work as-is and makes no representations or
+      warranties of any kind concerning the Work, express, implied,
+      statutory or otherwise, including without limitation warranties
+      of title, merchantability, fitness for a particular purpose, non
+      infringement, or the absence of latent or other defects,
+      accuracy, or the present or absence of errors, whether or not
+      discoverable, all to the greatest extent permissible under
+      applicable law.
+   c. Affirmer disclaims responsibility for clearing rights of other
+      persons that may apply to the Work or any use thereof, including
+      without limitation any person's Copyright and Related Rights in
+      the Work. Further, Affirmer disclaims responsibility for
+      obtaining any necessary consents, permissions or other rights
+      required for any use of the Work.
+   d. Affirmer understands and acknowledges that Creative Commons is
+      not a party to this document and has no duty or obligation with
+      respect to this CC0 or use of the Work.

--- a/COPYING-MIT-0
+++ b/COPYING-MIT-0
@@ -1,0 +1,16 @@
+Copyright 2021 Evan Nemerson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/hedley.h
+++ b/hedley.h
@@ -6,8 +6,13 @@
  * the public domain worldwide. This software is distributed without
  * any warranty.
  *
- * For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
- * SPDX-License-Identifier: CC0-1.0
+ * Alternatively, and at your option, this software is available under the
+ * MIT No Attribution License (MIT-0); see the file COPYING-MIT-0.
+ *
+ * For details, see <http://creativecommons.org/publicdomain/zero/1.0/> and the
+ * file COPYING-CC0-1.0, or <https://spdx.org/licenses/MIT-0.html> and the file
+ * COPYING-MIT-0.
+ * SPDX-License-Identifier: CC0-1.0 OR MIT-0
  */
 
 #if !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < 15)


### PR DESCRIPTION
Fixes #56.

MIT-0 license text based on https://opensource.org/license/mit-0.

@richardfontana This corresponds to a [Fedora package with `CC0-1.0` code using the exception for pre-existing code](https://src.fedoraproject.org/rpms/hedley/blob/1bf0e1ce0c194b49d641167c0640bc1c74b2ea7a/f/hedley.spec#_9). I brought it up in the original [“CC0 update status” issue](https://gitlab.com/fedora/legal/fedora-license-data/-/issues/32) – before that exception was formalized, I think – and [you commented on it](https://gitlab.com/fedora/legal/fedora-license-data/-/issues/32#note_1045465630). I had asked the author to consider relicensing or dual-licensing Hedley, and they just replied in https://github.com/nemequ/hedley/issues/56#issuecomment-2292422962. Since this PR is at Fedora’s request, would you mind taking a quick look to see if it looks “clean” from your perspective? Thanks!