### PR TITLE
Support older compilers in HEDLEY_STATIC_ASSERT

### DIFF
--- a/hedley.h
+++ b/hedley.h
@@ -1867,7 +1867,7 @@ HEDLEY_DIAGNOSTIC_POP
   HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
 #  define HEDLEY_STATIC_ASSERT(expr, message) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(static_assert(expr, message))
 #else
-#  define HEDLEY_STATIC_ASSERT(expr, message)
+#  define HEDLEY_STATIC_ASSERT(expr, message) struct { int static_assertion_failed: sizeof(int) * 8 + !(expr); }
 #endif
 
 #if defined(HEDLEY_NULL)


### PR DESCRIPTION
Implement static assert like funcionality on older compilers, the implementation do not support displaying human redable message, but compilation will fail.

Implementation works in any scope, also multiple uses of assert in the same line works fine.

Only issue is that it will generate warnings under gcc/clang due to use of unnamed struct with no instances.

The way to dissable the warning would be generating struct name using: `struct HEDLEY_CONCAT(_hedley_static_assert_, __COUNTER__) { ... }` under some compilers.
  